### PR TITLE
multiple files in single commit

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -237,7 +237,11 @@ func uploadFiles(refBranch string, branch string, gitObj *git.Git, files []strin
 	}
 
 	for _, file := range files {
-		destinationFile := strings.Replace(file, srcDir, destDir, 1)
+		relativePath, err := filepath.Rel(srcDir, file)
+		if err != nil {
+			return fmt.Errorf("failed to compute relative path: %w", err)
+		}
+		destinationFile := filepath.Join(destDir, relativePath)
 
 		fileContent, err := readFile(file)
 		if err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -4,7 +4,6 @@ import (
 	b64 "encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -140,12 +139,9 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		for _, file := range files {
-			detinationFile := strings.Replace(file, directory, destinationDirectory, 1)
-			err = uploadFile(refBranch, branch, gitObj, file, detinationFile)
-			if err != nil {
-				log.Fatal(err)
-			}
+		err = uploadFiles(refBranch, branch, gitObj, files, directory, destinationDirectory)
+		if err != nil {
+			log.Fatal(err)
 		}
 	}
 	if file != "" || directory != "" {
@@ -169,12 +165,11 @@ func main() {
 	} else {
 		log.Fatal("nothing to do")
 	}
-
 }
 
 func ioReadDir(root string) ([]string, error) {
 	var files []string
-	fileInfo, err := ioutil.ReadDir(root)
+	fileInfo, err := os.ReadDir(root)
 	if err != nil {
 		return files, err
 	}
@@ -231,6 +226,54 @@ func uploadFile(
 			fmt.Println("no changes file:", file)
 		}
 	}
+	return nil
+}
+
+func uploadFiles(refBranch string, branch string, gitObj *git.Git, files []string, srcDir string, destDir string) error {
+	batch := git.BatchFileUpdate{
+		Branch:  branch,
+		Message: fmt.Sprintf("Batch update files in %s", destDir),
+		Files:   make([]git.FileOperation, 0),
+	}
+
+	for _, file := range files {
+		destinationFile := strings.Replace(file, srcDir, destDir, 1)
+
+		fileContent, err := readFile(file)
+		if err != nil {
+			return err
+		}
+
+		fileObj, err := gitObj.GetAFile(refBranch, destinationFile)
+		if err != nil {
+			return err
+		}
+
+		encoded := b64.StdEncoding.EncodeToString(fileContent)
+
+		fileOp := git.FileOperation{
+			Path:    destinationFile,
+			Content: encoded,
+		}
+
+		if fileObj != nil {
+			if encoded != string(fileObj.Content) {
+				fileOp.Sha = fileObj.Sha
+				batch.Files = append(batch.Files, fileOp)
+				fmt.Println("updating file:", file)
+			} else {
+				fmt.Println("no changes file:", file)
+			}
+		} else {
+			batch.Files = append(batch.Files, fileOp)
+			fmt.Println("creating file:", file)
+		}
+	}
+
+	if len(batch.Files) > 0 {
+		return gitObj.CreateUpdateMultipleFiles(batch)
+	}
+
 	return nil
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -264,13 +264,13 @@ func uploadFiles(refBranch string, branch string, gitObj *git.Git, files []strin
 			if encoded != string(fileObj.Content) {
 				fileOp.Sha = fileObj.Sha
 				batch.Files = append(batch.Files, fileOp)
-				fmt.Println("updating file:", file)
+				log.Printf("INFO: updating file: %s", file)
 			} else {
-				fmt.Println("no changes file:", file)
+				log.Printf("INFO: no changes to file: %s", file)
 			}
 		} else {
 			batch.Files = append(batch.Files, fileOp)
-			fmt.Println("creating file:", file)
+			log.Printf("INFO: creating file: %s", file)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/pal-paul/git-copy
 
-go 1.21
+go 1.24
 
 require github.com/google/uuid v1.6.0

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -216,6 +216,15 @@ type BatchFileUpdate struct {
 	Files   []FileOperation `json:"files"`
 }
 
+// CreateUpdateMultipleFiles updates or creates multiple files in a repository branch.
+// 
+// Parameters:
+// - batch: A BatchFileUpdate struct containing the branch name, commit message, 
+//   and a list of files to be created or updated. Each file is represented by a 
+//   FileOperation struct, which includes the file path, content, and optional SHA.
+//
+// Returns:
+// - An error if the operation fails, or nil if the files are successfully updated.
 func (g *Git) CreateUpdateMultipleFiles(batch BatchFileUpdate) error {
 	reqBody := map[string]interface{}{
 		"branch":  batch.Branch,

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -238,7 +238,7 @@ func (g *Git) CreateUpdateMultipleFiles(batch BatchFileUpdate) error {
 		return err
 	}
 
-	if resp.StatusCode > 201 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("failed to update files: %s", resp.Status)
 	}
 


### PR DESCRIPTION
This PR introduces a batch file update feature, allowing multiple files to be updated in a single commit.

Adds new types (FileOperation, BatchFileUpdate) and the CreateUpdateMultipleFiles function in pkg/git/git.go.
Refactors the file upload process in cmd/cmd.go by replacing individual file uploads with the new uploadFiles function that handles batch updates.
