### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
         with:
           token: ${{ secrets.BOT_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: "go.mod"
 
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.no_changes == 'false'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           token: ${{ secrets.BOT_TOKEN }}
           commit-message: "chore: update Go dependencies"
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
         with:
           token: ${{ secrets.BOT_TOKEN }}
 
@@ -104,7 +104,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.no_changes == 'false'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           token: ${{ secrets.BOT_TOKEN }}
           commit-message: "chore: update GitHub Actions to latest versions"
@@ -147,10 +147,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: "go.mod"
 
@@ -165,7 +165,7 @@ jobs:
 
       - name: Create issue for vulnerabilities
         if: failure()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             github.rest.issues.create({

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: "go.mod"
           cache: true
@@ -40,7 +40,7 @@ jobs:
 
       - name: Create binary update PR
         id: binary-pr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
           base: master
@@ -77,12 +77,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: "go.mod"
           cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
@@ -69,7 +69,7 @@ jobs:
         run: go tool cover -html=coverage.out -o coverage.html
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v6.0.0
         with:
           file: ./coverage.out
           flags: unittests
@@ -127,7 +127,7 @@ jobs:
           ./cmd/app-git-copy 2>/dev/null || echo "✓ Directory-based operation validation passed!"
 
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: test-results-go${{ matrix.go-version }}
@@ -137,7 +137,7 @@ jobs:
           retention-days: 7
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         if: success()
         with:
           name: app-git-copy-go${{ matrix.go-version }}
@@ -150,10 +150,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: "go.mod"
 
@@ -195,7 +195,7 @@ jobs:
           echo "- Unsafe operations check: ✅ Passed" >> security-report.md
 
       - name: Upload Security Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: security-report
           path: security-report.md
@@ -207,10 +207,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: "go.mod"
 
@@ -227,10 +227,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: "go.mod"
 

--- a/.github/workflows/update-major-version-tag.yml
+++ b/.github/workflows/update-major-version-tag.yml
@@ -12,7 +12,7 @@ jobs:
             contents: write
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6.0.2
               with:
                   fetch-depth: 0
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v6.0.0](https://github.com/codecov/codecov-action/releases/tag/v6.0.0)** on 2026-03-26T14:01:32Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)** on 2026-01-09T19:53:28Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v8.1.1](https://github.com/peter-evans/create-pull-request/releases/tag/v8.1.1)** on 2026-04-10T16:27:57Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v7.0.1](https://github.com/actions/upload-artifact/releases/tag/v7.0.1)** on 2026-04-10T17:31:14Z
* **[actions/setup-go](https://github.com/actions/setup-go)** published a new release **[v6.4.0](https://github.com/actions/setup-go/releases/tag/v6.4.0)** on 2026-03-30T02:35:05Z
* **[actions/github-script](https://github.com/actions/github-script)** published a new release **[v9.0.0](https://github.com/actions/github-script/releases/tag/v9.0.0)** on 2026-04-09T22:57:15Z
